### PR TITLE
feat(store): t-017 layer naming defaults + properties rename + e2e config

### DIFF
--- a/guidance/feature/layer-naming/correlation_report.md
+++ b/guidance/feature/layer-naming/correlation_report.md
@@ -1,0 +1,28 @@
+---
+ticket: T-017
+feature: layer-naming
+author: preprod-qa
+date: 2025-09-04
+level: 1
+---
+
+## Summary
+
+- Initial scaffold ready. Correlates cleanly across three docs; no blockers.
+
+## Findings
+
+- Level consistency: ok
+- Scope symmetry: ok
+- AC traceability: ok
+- Naming/versioning: ok
+- Interfaces/contracts: ok
+- Risks/assumptions: ok
+
+## Required Edits
+
+- [ ] None
+
+## Go/No-Go
+
+- Status: clear

--- a/guidance/feature/layer-naming/product_requirements.md
+++ b/guidance/feature/layer-naming/product_requirements.md
@@ -1,0 +1,36 @@
+---
+ticket: T-017
+feature: layer-naming
+owner: product-owner
+date: 2025-09-04
+level: 1
+---
+
+## Problem & Value
+
+- New layers all default to the same label (e.g., "Hex Noise"), making scenes ambiguous.
+- Rename is available for Campaign/Map in Properties but not for selected Layer → inconsistency.
+- Clear names improve selection, duplication, and E2E assertions.
+
+## In Scope
+
+- Default numbered names on insert: "<Layer Title> <nn>" (zero‑padded, width 2).
+- Add a Name field for the selected layer in Properties; edits call `renameLayer`.
+- Duplicate keeps " Copy" suffix and does not renumber others.
+
+## Out of Scope
+
+- Scene panel inline rename (may follow later).
+- Global rename patterns or localization.
+
+## Acceptance Criteria
+
+- [ ] First Hex Noise insert → "Hex Noise 01"; second → "Hex Noise 02" (per map, per type).
+- [ ] Properties panel shows a Name input when a layer is selected; typing updates the layer name live.
+- [ ] Duplicating "Hex Noise 02" yields "Hex Noise 02 Copy".
+- [ ] Numbering skips existing names; inserting after rename to "Hex Noise Alps" still produces the next numeric suffix.
+
+## Risks & Assumptions
+
+- Assumes store insertion helpers accept an optional default name; numbering done in store for single source of truth.
+- Two‑digit padding is sufficient for MVP; can generalize later if needed.

--- a/guidance/feature/layer-naming/solutions_design.md
+++ b/guidance/feature/layer-naming/solutions_design.md
@@ -1,0 +1,30 @@
+---
+ticket: T-017
+feature: layer-naming
+author: lead-developer
+date: 2025-09-04
+level: 1
+---
+
+## Overview & Assumptions
+
+- Implement default numbering in `useProjectStore` at insertion points to keep logic centralized.
+- Expose Name field in Properties when selection.kind === 'layer', wiring to `renameLayer`.
+
+## Interfaces & Contracts
+
+- Store: augment `addLayer`, `insertLayerBeforeTopAnchor`, and `insertLayerAbove` to compute `name` when omitted.
+- Numbering rule per map, per layer type: scan existing names with prefix `<title> ` and 2‑digit suffix.
+
+## Data/State Changes
+
+- None to schema. Name remains `string` on `LayerInstance`.
+
+## Testing Strategy
+
+- Unit: pure helper that computes next name given a list of existing names.
+- E2E: create two Hex Noise layers → assert "01", "02"; rename via Properties; duplicate → "Copy" suffix.
+
+## Impact/Risks
+
+- Minimal perf impact (small arrays). Avoids UI‑only numbering to keep invariants.

--- a/guidance/feature/layer-naming/tasks.md
+++ b/guidance/feature/layer-naming/tasks.md
@@ -1,0 +1,18 @@
+---
+ticket: T-017
+feature: layer-naming
+author: production-coordinator
+date: 2025-09-04
+level: 1
+---
+
+## Tasks
+
+- [ ] Store: add `nextNumberedName(baseTitle, existing: string[]): string` helper and unit test.
+- [ ] Store: apply numbering when `name` param is absent in layer insert helpers.
+- [ ] UI: Properties panel — show `Name` input for selected layer; wire to `renameLayer`.
+- [ ] E2E: spec for numbering, rename in Properties, duplicate suffix.
+
+## Validation Hooks
+
+- `pnpm test` (unit) and `pnpm test:e2e` for the new flow.

--- a/guidance/feature/plugin-toolbar-contract/product_requirements.md
+++ b/guidance/feature/plugin-toolbar-contract/product_requirements.md
@@ -1,0 +1,40 @@
+---
+ticket: T-002
+feature: Plugin Toolbar Contract
+owner: product@countasone (PO)
+date: 2025-09-04
+level: 2
+---
+
+## Problem & Value
+
+- Hardcoded toolbar buttons block extensibility and violate platform goals in ADR-0002.
+- Plugins must contribute tools declaratively with predictable grouping/ordering.
+- Host must handle enablement (disabled + reason) via capability checks for clear UX.
+
+## In Scope
+
+- Contract for plugin-contributed toolbar items (groups, order, icon, label, command).
+- Capability-based enablement: disabled state with tooltip reason when preconditions fail.
+- Deterministic render order (group, then order, then label/command) and stable updates.
+- Remove remaining hardcoded tool buttons from the app toolbar.
+
+## Out of Scope
+
+- New visual design of toolbar; icons and spacing remain as-is.
+- Complex condition language or arbitrary code execution in plugins.
+- Command palette or keyboard shortcut registration beyond existing manifest `commands`.
+
+## Acceptance Criteria
+
+- [ ] No hardcoded tool buttons remain in `src/components/layout/app-toolbar.tsx`.
+- [ ] Plugins render solely from contributions; groups and items sort deterministically.
+- [ ] Capability checks drive `disabled` with tooltip reason when unmet (e.g., "Select a map to add a layer").
+- [ ] Contract documented and linked from ADR-0002 and 0006; examples provided.
+- [ ] Unit + integration tests cover ordering and enablement; E2E probes enable/disable states.
+
+## Risks & Assumptions
+
+- Keep plugin API narrow to avoid leaking host state shape; use named capability tokens.
+- Backward compatibility: existing plugins without preconditions still work (default enabled).
+- UX risk if reasons are inconsistent; provide host-side defaults for common tokens.

--- a/guidance/feature/plugin-toolbar-contract/solutions_design.md
+++ b/guidance/feature/plugin-toolbar-contract/solutions_design.md
@@ -1,0 +1,56 @@
+---
+ticket: T-002
+feature: Plugin Toolbar Contract
+author: leaddev@countasone
+date: 2025-09-04
+level: 2
+---
+
+## Overview & Assumptions
+
+- Goal: toolbar UI renders entirely from plugin contributions; host applies capability gating.
+- Assume existing command registration via `registerCommand()` remains the execution path.
+- Avoid exposing host state shape to plugins; use named capability tokens resolved by the host.
+
+## Interfaces & Contracts
+
+- Types (`src/plugin/types.ts`):
+  - Extend toolbar item with `preconditions?: string[]` and `label?: string`, `order?: number` (order already present), `icon?: string`.
+  - Manifest example:
+    - `contributes.toolbar = [{ group: "layers", items: [{ type: "button", command: "layer.hexnoise.add", icon: "layers", label: "Add Hex Noise", order: 10, preconditions: ["hasActiveMap"] }]}]`.
+
+- Capability Registry (host-only):
+  - New module `src/plugin/capabilities.ts` exports `resolvePreconditions(tokens: string[]): { enabled: boolean; reason?: string }`.
+  - Built-in tokens (MVP): `hasActiveMap`, `hasProject`, `canSave`.
+  - Each token maps to a predicate over stores (e.g., `useProjectStore`).
+
+- Loader (`src/plugin/loader.ts`):
+  - Keep contributions data structure; store `preconditions` as provided.
+  - Emit `plugin:toolbar-updated` on load/unload unchanged.
+
+- Toolbar (`src/components/layout/app-toolbar.tsx`):
+  - Replace command-specific checks with generic capability evaluation via `resolvePreconditions`.
+  - Compute `disabled` and `tooltip` reason per item based on `preconditions`.
+  - Preserve existing grouping and sorting behavior; remove special casing.
+
+## Data/State Changes
+
+- No persistent schema changes. New runtime-only capability registry. Types extended for toolbar items.
+
+## Testing Strategy
+
+- Unit:
+  - Capability registry resolves tokens correctly given mocked store state.
+  - Sorting is deterministic across groups and items (order → label/command).
+  - Loader retains contributions and surfaces `preconditions` unchanged.
+- Integration (React):
+  - Toolbar renders items from contributions; disabled state toggles when store state changes.
+  - Tooltip reason text reflects unmet capability (e.g., `hasActiveMap`).
+- E2E (baseline):
+  - With no active map, "Add Hex Noise" button appears disabled with reason; enabled after selecting/creating a map.
+
+## Impact/Risks
+
+- Perf: minimal; evaluation is O(items) per render with simple predicates.
+- DX/UX: clearer contract; consistent tooltips for unmet preconditions.
+- ADR links: ADR-0002 (Plugin Architecture), ADR-0006 (Toolbar Structure Policy).

--- a/guidance/feature/plugin-toolbar-contract/tasks.md
+++ b/guidance/feature/plugin-toolbar-contract/tasks.md
@@ -1,0 +1,33 @@
+---
+ticket: T-002
+feature: Plugin Toolbar Contract
+author: prodcoord@countasone
+date: 2025-09-04
+level: 2
+---
+
+## Milestones & Gates
+
+- M1: Types + registry in place; unit tests green.
+- M2: Toolbar refactor complete; integration tests green.
+- M3: E2E probe added; CI green; docs linked.
+
+## Tasks
+
+- [ ] Extend types: add `preconditions?: string[]` to toolbar item (owner: @dev, est: 1h, deps: none)
+- [ ] Add capability registry `src/plugin/capabilities.ts` with `hasActiveMap` (owner: @dev, est: 2h, deps: stores)
+- [ ] Update loader to retain `preconditions` (owner: @dev, est: 1h, deps: types)
+- [ ] Refactor `AppToolbar` to evaluate `preconditions` generically; remove special casing (owner: @dev, est: 2h, deps: registry)
+- [ ] Unit tests: sorting, registry predicates (owner: @qa-dev, est: 2h, deps: types)
+- [ ] Integration tests: disabled/enabled toggle via store changes (owner: @qa-dev, est: 3h, deps: toolbar)
+- [ ] E2E: toolbar enablement probe for hex noise add (owner: @qa, est: 2h, deps: M2)
+- [ ] Docs: update ADR-0002 references; add brief to `guidance/process/implementation_standards.md` (owner: @doc, est: 1h)
+
+## Validation Hooks
+
+- `pnpm test` covers unit/integration; `pnpm test:e2e` adds enablement probe.
+- Mapping: sorting → unit; enablement → integration; end-to-end toggle → e2e.
+
+## Rollback / Flag
+
+Removed per product direction (greenfield, no rollback path needed). Make it right.

--- a/guidance/process/documentation_structure.md
+++ b/guidance/process/documentation_structure.md
@@ -12,6 +12,7 @@ guidance/feature/{feature_name}/
 │   ├── requirements.md              # Product Owner: business needs & user stories
 │   ├── solutions_design.md          # Lead Developer: technical architecture
 │   ├── tasks.md                     # Production Coordinator: task breakdown
+│   ├── correlation_report.md        # Pre‑prod QA (optional): inconsistencies & fixes
 │   └── delegation_log.md            # Agent tracking & decisions
 ├── ux/                              # UX Designer artifacts (Level 2+ features)
 │   ├── user-journey.md             # User experience mapping
@@ -49,6 +50,14 @@ guidance/feature/{feature_name}/
 - Task dependencies and execution order
 - Complexity-appropriate detail level
 - Progress tracking with clear status indicators
+
+### correlation_report.md (Pre‑prod QA — optional)
+
+Purpose: Correlate the three artifacts; highlight inconsistencies and required edits. Not a QA plan.
+
+- Level consistency, scope symmetry, AC traceability
+- Naming/versioning alignment and interface/contract cross‑check
+- Red flags and required edits before implementation/merge
 
 ### ux/ Directory (UX Designer)
 

--- a/guidance/process/feature_workflow.md
+++ b/guidance/process/feature_workflow.md
@@ -1,0 +1,40 @@
+# Feature Workflow (Roles → Artifacts)
+
+This workflow coordinates four roles to produce three core artifacts per feature, with depth proportional to complexity (see guidance/process/complexity_effort_classification.md).
+
+## Roles and Outputs
+
+- Product Owner → `product_requirements.md`
+- Lead Developer → `solutions_design.md`
+- Production Coordinator → `tasks.md`
+- Pre‑prod QA → correlates the three artifacts; optional `correlation_report.md` for findings (no test plan)
+
+## Folder Convention
+
+- Base: `guidance/feature/{ticket_or_feature_name}/` (preferred). If an existing feature already uses `planning/`, place these files there instead.
+- Examples:
+  - `guidance/feature/layer-naming/product_requirements.md`
+  - `guidance/feature/layer-naming/solutions_design.md`
+  - `guidance/feature/layer-naming/tasks.md`
+  - `guidance/feature/layer-naming/quality_plan.md`
+
+## Minimal, Proportional Effort
+
+- Classify feature Level 1/2/3 first (Complexity & Effort Framework).
+- All four artifacts exist at every level, but shrink/grow in detail:
+  - Level 1: micro‑docs (≤1 page each; bullets only)
+  - Level 2: focused docs (2–5 pages total across all)
+  - Level 3: comprehensive docs (as needed)
+
+## Hand‑Off Order and Gates
+
+1. Product Owner drafts `product_requirements.md` with level and acceptance criteria.
+2. Lead Dev proposes `solutions_design.md` and lists decisions/assumptions.
+3. Production Coordinator breaks down into `tasks.md` with dependencies/owners.
+4. Pre‑prod QA runs correlation review across the three docs; posts findings in `correlation_report.md` (optional) and triggers iteration if inconsistencies exist.
+
+Merge to `main` only when the first three exist, reference the same level, and Pre‑prod QA reports no blocking inconsistencies.
+
+## Templates
+
+Use the templates in `guidance/templates/*.template.md` to bootstrap each file.

--- a/guidance/process/feature_workflow.md
+++ b/guidance/process/feature_workflow.md
@@ -38,3 +38,11 @@ Merge to `main` only when the first three exist, reference the same level, and P
 ## Templates
 
 Use the templates in `guidance/templates/*.template.md` to bootstrap each file.
+
+## Commit & PR Hygiene
+
+- Use Conventional Commits to satisfy commitlint and avoid retries:
+  - Examples: `docs(process): add role processes`, `feat(ui): add layer name field`, `test(e2e): assert numbering`.
+- Don’t commit to `main`; pre-commit blocks it. Work on a feature branch like `feat/layer-naming`.
+- Keep commits scoped: one logical change per commit; guidance vs feature in separate commits.
+- Ensure staged files pass format/lint hooks; Prettier and ESLint run on staged files.

--- a/guidance/process/lead_developer_process.md
+++ b/guidance/process/lead_developer_process.md
@@ -1,0 +1,36 @@
+# Lead Developer Process
+
+Purpose: Translate requirements into a practical solution design with minimal ceremony.
+
+Primary artifact: `guidance/feature/{ticket}/solutions_design.md`
+
+Reference: guidance/process/complexity_effort_classification.md
+
+## Responsibilities
+
+- Confirm complexity level and dependencies.
+- Propose architecture, interfaces, and data flows.
+- Record key decisions and ADR links where applicable.
+
+## Depth by Level
+
+- Level 1: One‑pager max: approach, API surface, affected files, risks.
+- Level 2: Focused design: diagrams if helpful, test points, rollback plan.
+- Level 3: Comprehensive: choices, tradeoffs, sequencing, migration.
+
+## Required Sections (any level)
+
+- Overview & Assumptions
+- Interfaces & Contracts (types, props, store methods)
+- Data/State Changes (schema, defaults, migration notes)
+- Testing Strategy (unit/integration/E2E probes)
+- Impact/Risks (perf, DX, UX)
+
+Use `guidance/templates/solutions_design.template.md` to start.
+
+## Heuristics
+
+- Choose the smallest viable interface; extend later behind existing seams.
+- Put invariants in the store/adapter (single source of truth), not just the UI.
+- Link to relevant ADRs; open a new ADR only for architectural changes.
+- Sketch tests before coding to anchor contracts and avoid scope drift.

--- a/guidance/process/preprod_qa_process.md
+++ b/guidance/process/preprod_qa_process.md
@@ -1,0 +1,33 @@
+# Pre‑prod QA Process (Correlation & Iteration)
+
+Purpose: Correlate the three feature artifacts (requirements, design, tasks) to surface inconsistencies early and trigger a fast corrective loop. This role does not author a QA plan.
+
+Reference: guidance/process/complexity_effort_classification.md
+
+## Responsibilities
+
+- Validate alignment across documents: same feature scope, same complexity level, consistent acceptance criteria.
+- Trace acceptance criteria → design sections → tasks; flag missing links or contradictions.
+- Check for over/under‑scoping relative to level (guard against ceremony creep for Level 1).
+- Raise issues and request targeted edits; capture optional findings in `correlation_report.md`.
+
+## Correlation Checklist (all levels)
+
+- Level consistency: all three docs declare the same level and the depth matches it.
+- Scope symmetry: items listed as In‑Scope appear in design and in tasks.
+- AC traceability: each AC is implemented (design) and executable (task/test hook).
+- Naming/versioning: ticket id and feature name match across files and branches.
+- Interfaces: contracts in design correspond to tasks touching the right files/modules.
+- Risk/assumption closure: assumptions in requirements/design have tasks to validate or remove them.
+
+## Red Flags (trigger iteration)
+
+- Requirements list 10+ ACs for a Level 1 feature.
+- Design proposes new subsystems without matching scope/level or ADR.
+- Tasks don’t reference acceptance criteria or lack validation hooks.
+- Ambiguous terms (“improve”, “optimize”) without measurable outcomes.
+
+## Output
+
+- Preferred: inline comments/edits on the three docs and a short summary in the PR.
+- Optional: `guidance/feature/{ticket}/correlation_report.md` using the template.

--- a/guidance/process/product_owner_process.md
+++ b/guidance/process/product_owner_process.md
@@ -1,0 +1,36 @@
+# Product Owner Process
+
+Purpose: Produce concise product requirements aligned with complexity level.
+
+Primary artifact: `guidance/feature/{ticket}/product_requirements.md`
+
+Reference: guidance/process/complexity_effort_classification.md
+
+## Responsibilities
+
+- Classify feature Level 1/2/3 and state it up front.
+- Define problem, outcomes, scope boundaries, and acceptance criteria.
+- Capture user stories and non‑functional constraints relevant to value.
+
+## Depth by Level
+
+- Level 1: 3–7 bullets total (problem, short scope, 3–5 ACs). No diagrams.
+- Level 2: Focused narrative (≤1 page) + ACs; optional lightweight diagram.
+- Level 3: Full narrative with alternatives and risks.
+
+## Required Sections (any level)
+
+- Meta: ticket/id, owner, date, level
+- Problem & Value
+- Out of Scope (keep tight)
+- Acceptance Criteria (testable; enable traceability, not a QA plan)
+- Risks/Assumptions (bullets)
+
+Use `guidance/templates/product_requirements.template.md` to start.
+
+## Heuristics
+
+- Keep Level 1 ruthlessly short: 3–7 bullets and 3–5 ACs max.
+- Prefer concrete, observable ACs; avoid "improve/optimize" without a measure.
+- Declare what won’t be done (Out of Scope) to prevent creep.
+- Reuse existing concepts (stores, adapters) rather than inventing new primitives.

--- a/guidance/process/production_coordinator_process.md
+++ b/guidance/process/production_coordinator_process.md
@@ -1,0 +1,35 @@
+# Production Coordinator Process
+
+Purpose: Plan execution with just enough structure to keep flow moving.
+
+Primary artifact: `guidance/feature/{ticket}/tasks.md`
+
+Reference: guidance/process/complexity_effort_classification.md
+
+## Responsibilities
+
+- Break feature into verifiable tasks and small PRs.
+- Map dependencies and critical path; align with tooling (pnpm, tests, lint).
+- Ensure tasks reference acceptance criteria and test points.
+
+## Depth by Level
+
+- Level 1: 2–5 tasks; single PR acceptable; checklist OK.
+- Level 2: 5–15 tasks; multiple PRs; staged merges; E2E probe.
+- Level 3: Full plan with milestones, risk burndown, and rollbacks.
+
+## Required Sections (any level)
+
+- Milestones (if any) and gates
+- Task list with owners, estimates, dependencies
+- Test/Validation hooks per task
+- Rollback/feature flag (when relevant)
+
+Use `guidance/templates/tasks.template.md` to start.
+
+## Heuristics
+
+- Keep PRs small and independently shippable; one behavior per PR when possible.
+- Attach validation to each task (unit/integration/E2E) to avoid late QA surprises.
+- Sequence by risk: land the invariant‑holding changes first (e.g., store logic), then UI.
+- Respect the level: don’t generate 30 tasks for a Level 1 change.

--- a/guidance/process/templates/correlation_report.template.md
+++ b/guidance/process/templates/correlation_report.template.md
@@ -1,0 +1,30 @@
+---
+ticket: T-XXX
+feature: <feature_name>
+author: <preprod_qa>
+date: <YYYY-MM-DD>
+level: <1|2|3>
+---
+
+## Summary
+
+- <one-paragraph outcome>
+
+## Findings
+
+- Level consistency: <ok/issue>
+- Scope symmetry: <ok/issue>
+- AC traceability: <ok/issue>
+- Naming/versioning: <ok/issue>
+- Interfaces/contracts: <ok/issue>
+- Risks/assumptions: <ok/issue>
+
+## Required Edits
+
+- [ ] Requirements: <edit>
+- [ ] Design: <edit>
+- [ ] Tasks: <edit>
+
+## Go/No-Go
+
+- Status: <proceed after fixes | blocked | clear>

--- a/guidance/process/templates/product_requirements.template.md
+++ b/guidance/process/templates/product_requirements.template.md
@@ -1,0 +1,28 @@
+---
+ticket: T-XXX
+feature: <feature_name>
+owner: <product_owner>
+date: <YYYY-MM-DD>
+level: <1|2|3>
+---
+
+## Problem & Value
+
+- <1–3 bullets>
+
+## In Scope
+
+- <bullets>
+
+## Out of Scope
+
+- <bullets>
+
+## Acceptance Criteria
+
+- [ ] <Given/When/Then or concise check>
+- [ ] <...>
+
+## Risks & Assumptions
+
+- <bullets>

--- a/guidance/process/templates/solutions_design.template.md
+++ b/guidance/process/templates/solutions_design.template.md
@@ -1,0 +1,32 @@
+---
+ticket: T-XXX
+feature: <feature_name>
+author: <lead_dev>
+date: <YYYY-MM-DD>
+level: <1|2|3>
+---
+
+## Overview & Assumptions
+
+- <bullets>
+
+## Interfaces & Contracts
+
+- API/store changes: `useProjectStore().<method>` …
+- Types: `src/types/...`
+
+## Data/State Changes
+
+- <schema/state deltas and defaults>
+
+## Testing Strategy
+
+- Unit: <areas>
+- Integration: <flows>
+- E2E: <critical probe>
+
+## Impact/Risks
+
+- Perf: <notes>
+- DX/UX: <notes>
+- ADR links: <refs>

--- a/guidance/process/templates/tasks.template.md
+++ b/guidance/process/templates/tasks.template.md
@@ -1,0 +1,24 @@
+---
+ticket: T-XXX
+feature: <feature_name>
+author: <production_coordinator>
+date: <YYYY-MM-DD>
+level: <1|2|3>
+---
+
+## Milestones & Gates
+
+- <optional>
+
+## Tasks
+
+- [ ] <task> (owner: @, est: h/d, deps: …)
+- [ ] <task>
+
+## Validation Hooks
+
+- `pnpm test` / `pnpm test:e2e` checks for tasks: <mapping>
+
+## Rollback / Flag
+
+- <if applicable>

--- a/guidance/templates/correlation_report.template.md
+++ b/guidance/templates/correlation_report.template.md
@@ -1,0 +1,30 @@
+---
+ticket: T-XXX
+feature: <feature_name>
+author: <preprod_qa>
+date: <YYYY-MM-DD>
+level: <1|2|3>
+---
+
+## Summary
+
+- <one-paragraph outcome>
+
+## Findings
+
+- Level consistency: <ok/issue>
+- Scope symmetry: <ok/issue>
+- AC traceability: <ok/issue>
+- Naming/versioning: <ok/issue>
+- Interfaces/contracts: <ok/issue>
+- Risks/assumptions: <ok/issue>
+
+## Required Edits
+
+- [ ] Requirements: <edit>
+- [ ] Design: <edit>
+- [ ] Tasks: <edit>
+
+## Go/No-Go
+
+- Status: <proceed after fixes | blocked | clear>

--- a/guidance/templates/product_requirements.template.md
+++ b/guidance/templates/product_requirements.template.md
@@ -1,0 +1,28 @@
+---
+ticket: T-XXX
+feature: <feature_name>
+owner: <product_owner>
+date: <YYYY-MM-DD>
+level: <1|2|3>
+---
+
+## Problem & Value
+
+- <1–3 bullets>
+
+## In Scope
+
+- <bullets>
+
+## Out of Scope
+
+- <bullets>
+
+## Acceptance Criteria
+
+- [ ] <Given/When/Then or concise check>
+- [ ] <...>
+
+## Risks & Assumptions
+
+- <bullets>

--- a/guidance/templates/solutions_design.template.md
+++ b/guidance/templates/solutions_design.template.md
@@ -1,0 +1,32 @@
+---
+ticket: T-XXX
+feature: <feature_name>
+author: <lead_dev>
+date: <YYYY-MM-DD>
+level: <1|2|3>
+---
+
+## Overview & Assumptions
+
+- <bullets>
+
+## Interfaces & Contracts
+
+- API/store changes: `useProjectStore().<method>` …
+- Types: `src/types/...`
+
+## Data/State Changes
+
+- <schema/state deltas and defaults>
+
+## Testing Strategy
+
+- Unit: <areas>
+- Integration: <flows>
+- E2E: <critical probe>
+
+## Impact/Risks
+
+- Perf: <notes>
+- DX/UX: <notes>
+- ADR links: <refs>

--- a/guidance/templates/tasks.template.md
+++ b/guidance/templates/tasks.template.md
@@ -1,0 +1,24 @@
+---
+ticket: T-XXX
+feature: <feature_name>
+author: <production_coordinator>
+date: <YYYY-MM-DD>
+level: <1|2|3>
+---
+
+## Milestones & Gates
+
+- <optional>
+
+## Tasks
+
+- [ ] <task> (owner: @, est: h/d, deps: …)
+- [ ] <task>
+
+## Validation Hooks
+
+- `pnpm test` / `pnpm test:e2e` checks for tasks: <mapping>
+
+## Rollback / Flag
+
+- <if applicable>

--- a/guidance/todos.md
+++ b/guidance/todos.md
@@ -1,12 +1,11 @@
 ## TODOs
 
+- NEXT — Layer naming UX: default numbering + properties‑panel rename. When inserting a layer without a provided name, default to `<Layer Title> <n>` where `n` is the next available number for that type within the active map (e.g., `Hex Noise 1`, `Hex Noise 2`). Add a `Name` field for selected layer in the Properties panel (parity with Campaign/Map) wired to `renameLayer`. Optional later: inline rename in scene panel (click/F2) if needed after parity lands. E2E: create 2 Hex Noise layers and assert numbered names; rename via Properties persists; duplicate preserves “Copy” suffix and does not renumber others.
 - Workflow: document agent Git workflow in `AGENTS.md` (branch naming, lint/test gates, PR protocol). (Done)
-- Layering model: make stacking intuitive and consistent across sidebar, renderers, and insertion/duplication. Decide canonical order (array order vs. fixed sentinels), fix insertion semantics, and add tests + UI indicators (e.g., z-order badges/arrows).
+- Layering model: align implementation and UI with ADR‑0013 (anchors + insertion semantics). Verify array order is the single source of truth, anchors are fixed (paper bottom, hexgrid top), and scene panel mirrors top‑of‑render at top of list. Add/confirm tests. (Done)
 - Theming audit: run `guidance/process/theming_audit_checklist.md` and address findings (tokens, contrast, states, dark-mode gaps).
-- Dark mode toggle: expose a visible toggle in header; wire to `useLayoutStore().theme` and verify all views in dark. (Done)
 - Plugin toolbar: remove any hardcoded tool buttons; ensure the toolbar is fully contribution-driven (commands + groups + order), with disabled tooltips and capability gating.
 - Terrain colors injection: remove hardcoded colors from renderers; source from a map “setting”/palette or theme tokens. Provide a small API/context for layers to read current palette.
-- Layer rename: enable inline renaming in the scene panel (store already supports `renameLayer`).
 - Layer reorder: add drag-and-drop or up/down controls in the scene panel (store has `moveLayer`).
 - Map properties: remove “visibility” control from the map item in the properties panel; keep map visibility implicit via selection/active map. (Done)
 - Layers UX: design pass on layers panel (grouping, icons, reordering affordances, lock/visibility consistency, insertion feedback) with a short spec + mocks.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,25 +1,28 @@
-import { defineConfig, devices } from '@playwright/test';
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = Number(process.env.PORT) || 3000;
+const BASE_URL = `http://127.0.0.1:${PORT}`;
 
 export default defineConfig({
-  testDir: './src/test/e2e',
+  testDir: "./src/test/e2e",
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
-  reporter: 'html',
+  reporter: "html",
   use: {
-    baseURL: 'http://127.0.0.1:3000',
-    trace: 'on-first-retry',
+    baseURL: BASE_URL,
+    trace: "on-first-retry",
   },
   projects: [
     {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
     },
   ],
   webServer: {
-    command: 'pnpm dev',
-    url: 'http://127.0.0.1:3000',
+    command: `PORT=${PORT} pnpm dev`,
+    url: BASE_URL,
     reuseExistingServer: !process.env.CI,
   },
 });

--- a/src/components/layout/properties-panel.tsx
+++ b/src/components/layout/properties-panel.tsx
@@ -1,26 +1,37 @@
-'use client';
+"use client";
 
-import React from 'react';
-import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
-import { Button } from '@/components/ui/button';
-import { ColorField, SelectField } from '@/components/properties';
-import { Slider } from '@/components/ui/slider';
-import { getPropertySchema } from '@/properties/registry';
-import { Separator } from '@/components/ui/separator';
+import React from "react";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { ColorField, SelectField } from "@/components/properties";
+import { Slider } from "@/components/ui/slider";
+import { getPropertySchema } from "@/properties/registry";
+import { Separator } from "@/components/ui/separator";
 
-import { useLayoutStore } from '@/stores/layout';
-import { useSelectionStore } from '@/stores/selection';
-import { useProjectStore } from '@/stores/project';
+import { useLayoutStore } from "@/stores/layout";
+import { useSelectionStore } from "@/stores/selection";
+import { useProjectStore } from "@/stores/project";
 
-interface PropertiesPanelProps { className?: string }
+interface PropertiesPanelProps {
+  className?: string;
+}
 
-export const PropertiesPanel: React.FC<PropertiesPanelProps> = ({ className = '' }) => {
-  const propertiesPanelOpen = useLayoutStore((state) => state.propertiesPanelOpen);
+export const PropertiesPanel: React.FC<PropertiesPanelProps> = ({
+  className = "",
+}) => {
+  const propertiesPanelOpen = useLayoutStore(
+    (state) => state.propertiesPanelOpen,
+  );
   if (!propertiesPanelOpen) return null;
   return (
-    <div className={`h-full w-full border-l bg-background flex flex-col min-h-0 ${className}`} data-testid="properties-panel">
-      <div className="p-3 border-b text-xs font-medium text-muted-foreground">Properties</div>
+    <div
+      className={`h-full w-full border-l bg-background flex flex-col min-h-0 ${className}`}
+      data-testid="properties-panel"
+    >
+      <div className="p-3 border-b text-xs font-medium text-muted-foreground">
+        Properties
+      </div>
       <div className="p-3 space-y-4 overflow-auto">
         <CampaignProperties />
         <MapProperties />
@@ -36,10 +47,16 @@ const FieldLabel: React.FC<{ label: string }> = ({ label }) => (
   <div className="text-xs text-foreground mb-1">{label}</div>
 );
 
-const Group: React.FC<{ title: string; children: React.ReactNode; actions?: React.ReactNode }> = ({ title, children, actions }) => (
+const Group: React.FC<{
+  title: string;
+  children: React.ReactNode;
+  actions?: React.ReactNode;
+}> = ({ title, children, actions }) => (
   <div>
     <div className="flex items-center justify-between mb-2">
-      <div className="text-[11px] uppercase tracking-wide text-foreground">{title}</div>
+      <div className="text-[11px] uppercase tracking-wide text-foreground">
+        {title}
+      </div>
       {actions}
     </div>
     <div className="space-y-3">{children}</div>
@@ -52,16 +69,27 @@ const CampaignProperties: React.FC = () => {
   const project = useProjectStore((s) => s.current);
   const rename = useProjectStore((s) => s.rename);
   const setDescription = useProjectStore((s) => s.setDescription);
-  if (selection.kind !== 'campaign' || !project) return null;
+  if (selection.kind !== "campaign" || !project) return null;
   return (
     <Group title="Campaign">
       <div>
         <FieldLabel label="Name" />
-        <Input value={project.name} onChange={(e) => rename(e.target.value)} placeholder="Untitled Campaign" aria-label="Campaign Name" />
+        <Input
+          value={project.name}
+          onChange={(e) => rename(e.target.value)}
+          placeholder="Untitled Campaign"
+          aria-label="Campaign Name"
+        />
       </div>
       <div>
         <FieldLabel label="Description" />
-        <Textarea value={project.description ?? ''} onChange={(e) => setDescription(e.target.value)} placeholder="Optional description" rows={5} aria-label="Campaign Description" />
+        <Textarea
+          value={project.description ?? ""}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="Optional description"
+          rows={5}
+          aria-label="Campaign Description"
+        />
       </div>
     </Group>
   );
@@ -74,18 +102,40 @@ const MapProperties: React.FC = () => {
   const setMapDescription = useProjectStore((s) => s.setMapDescription);
   const setMapPaperAspect = useProjectStore((s) => s.setMapPaperAspect);
   const setMapPaperColor = useProjectStore((s) => s.setMapPaperColor);
-  if (selection.kind !== 'map' || !project) return null;
-  const map = project.maps.find((m) => m.id === selection.id); if (!map) return null;
-  const resetPaper = () => { setMapPaperAspect(map.id, '16:10'); setMapPaperColor(map.id, '#ffffff'); };
+  if (selection.kind !== "map" || !project) return null;
+  const map = project.maps.find((m) => m.id === selection.id);
+  if (!map) return null;
+  const resetPaper = () => {
+    setMapPaperAspect(map.id, "16:10");
+    setMapPaperColor(map.id, "#ffffff");
+  };
   return (
-    <Group title="Map" actions={<Button size="sm" variant="outline" onClick={resetPaper}>Reset Paper</Button>}>
+    <Group
+      title="Map"
+      actions={
+        <Button size="sm" variant="outline" onClick={resetPaper}>
+          Reset Paper
+        </Button>
+      }
+    >
       <div>
         <FieldLabel label="Title" />
-        <Input value={map.name} onChange={(e) => renameMap(map.id, e.target.value)} placeholder="Untitled Map" aria-label="Map Title" />
+        <Input
+          value={map.name}
+          onChange={(e) => renameMap(map.id, e.target.value)}
+          placeholder="Untitled Map"
+          aria-label="Map Title"
+        />
       </div>
       <div>
         <FieldLabel label="Description" />
-        <Textarea value={map.description ?? ''} onChange={(e) => setMapDescription(map.id, e.target.value)} placeholder="Optional description" rows={4} aria-label="Map Description" />
+        <Textarea
+          value={map.description ?? ""}
+          onChange={(e) => setMapDescription(map.id, e.target.value)}
+          placeholder="Optional description"
+          rows={4}
+          aria-label="Map Description"
+        />
       </div>
       {/* Map visibility control removed; visibility implied by active selection */}
     </Group>
@@ -96,45 +146,97 @@ const LayerPropertiesGeneric: React.FC = () => {
   const selection = useSelectionStore((s) => s.selection);
   const project = useProjectStore((s) => s.current);
   const updateLayerState = useProjectStore((s) => s.updateLayerState);
-  if (selection.kind !== 'layer' || !project) return null;
-  const map = project.maps.find((m) => m.id === project.activeMapId); if (!map) return null;
-  const layer = (map.layers ?? []).find((l) => l.id === selection.id); if (!layer) return null;
+  const renameLayer = useProjectStore((s) => s.renameLayer);
+  if (selection.kind !== "layer" || !project) return null;
+  const map = project.maps.find((m) => m.id === project.activeMapId);
+  if (!map) return null;
+  const layer = (map.layers ?? []).find((l) => l.id === selection.id);
+  if (!layer) return null;
   const scope = `layer:${layer.type}`;
-  const schema = getPropertySchema(scope); if (!schema) return null;
-  const getVal = (path: string) => (layer.state as Record<string, unknown> | undefined)?.[path as keyof Record<string, unknown>];
-  const setVal = (path: string, val: unknown) => updateLayerState(layer.id, { [path]: val });
+  const schema = getPropertySchema(scope);
+  if (!schema) return null;
+  const getVal = (path: string) =>
+    (layer.state as Record<string, unknown> | undefined)?.[
+      path as keyof Record<string, unknown>
+    ];
+  const setVal = (path: string, val: unknown) =>
+    updateLayerState(layer.id, { [path]: val });
   return (
     <>
+      <Group title="Layer">
+        <div>
+          <FieldLabel label="Name" />
+          <Input
+            aria-label="Layer Name"
+            value={layer.name ?? ""}
+            onChange={(e) => renameLayer(layer.id, e.target.value)}
+            placeholder="Layer Name"
+          />
+        </div>
+      </Group>
       {schema.groups.map((g) => (
         <Group key={g.id} title={g.title}>
           {g.rows.map((row, idx) => {
             const fields = Array.isArray(row) ? row : [row];
             return (
-              <div key={idx} className={fields.length > 1 ? 'grid grid-cols-2 gap-2' : ''}>
+              <div
+                key={idx}
+                className={fields.length > 1 ? "grid grid-cols-2 gap-2" : ""}
+              >
                 {fields.map((f) => {
-                  if (f.kind === 'select') {
-                    const v = getVal(f.path) ?? '';
-                    return <SelectField key={f.id} label={f.label} value={String(v)} options={f.options} onChange={(val) => setVal(f.path, val)} />;
+                  if (f.kind === "select") {
+                    const v = getVal(f.path) ?? "";
+                    return (
+                      <SelectField
+                        key={f.id}
+                        label={f.label}
+                        value={String(v)}
+                        options={f.options}
+                        onChange={(val) => setVal(f.path, val)}
+                      />
+                    );
                   }
-                  if (f.kind === 'color') {
-                    const v = getVal(f.path) ?? '#ffffff';
-                    return <ColorField key={f.id} label={f.label} value={String(v)} onChange={(val) => setVal(f.path, val)} />;
+                  if (f.kind === "color") {
+                    const v = getVal(f.path) ?? "#ffffff";
+                    return (
+                      <ColorField
+                        key={f.id}
+                        label={f.label}
+                        value={String(v)}
+                        onChange={(val) => setVal(f.path, val)}
+                      />
+                    );
                   }
-                  if (f.kind === 'number') {
+                  if (f.kind === "number") {
                     const v = Number(getVal(f.path) ?? 0);
                     return (
                       <div key={f.id}>
                         <FieldLabel label={f.label || f.id} />
-                        <Input type="number" value={v} min={f.min} max={f.max} step={f.step ?? 1} onChange={(e) => setVal(f.path, Number(e.target.value))} />
+                        <Input
+                          type="number"
+                          value={v}
+                          min={f.min}
+                          max={f.max}
+                          step={f.step ?? 1}
+                          onChange={(e) =>
+                            setVal(f.path, Number(e.target.value))
+                          }
+                        />
                       </div>
                     );
                   }
-                  if (f.kind === 'slider') {
+                  if (f.kind === "slider") {
                     const v = Number(getVal(f.path) ?? 0);
                     return (
                       <div key={f.id}>
                         <FieldLabel label={f.label || f.id} />
-                        <Slider value={v} min={f.min} max={f.max} step={f.step ?? 1} onChange={(val) => setVal(f.path, val)} />
+                        <Slider
+                          value={v}
+                          min={f.min}
+                          max={f.max}
+                          step={f.step ?? 1}
+                          onChange={(val) => setVal(f.path, val)}
+                        />
                       </div>
                     );
                   }

--- a/src/plugin/builtin/hex-noise.ts
+++ b/src/plugin/builtin/hex-noise.ts
@@ -45,11 +45,11 @@ export const hexNoiseModule: PluginModule = {
         // Try to insert above selection; if target is top anchor, fall back to just below grid
         let id = useProjectStore
           .getState()
-          .insertLayerAbove(sel.id, "hexnoise", "Hex Noise");
+          .insertLayerAbove(sel.id, "hexnoise");
         if (!id) {
           id = useProjectStore
             .getState()
-            .insertLayerBeforeTopAnchor("hexnoise", "Hex Noise");
+            .insertLayerBeforeTopAnchor("hexnoise");
         }
         if (!id) return;
         useSelectionStore.getState().selectLayer(id);
@@ -57,7 +57,7 @@ export const hexNoiseModule: PluginModule = {
       } else if (sel.kind === "map") {
         const id = useProjectStore
           .getState()
-          .insertLayerBeforeTopAnchor("hexnoise", "Hex Noise");
+          .insertLayerBeforeTopAnchor("hexnoise");
         if (!id) return;
         useSelectionStore.getState().selectLayer(id);
         return;
@@ -65,7 +65,7 @@ export const hexNoiseModule: PluginModule = {
       // Fallback when nothing is selected: treat as map-level insert
       const id = useProjectStore
         .getState()
-        .insertLayerBeforeTopAnchor("hexnoise", "Hex Noise");
+        .insertLayerBeforeTopAnchor("hexnoise");
       if (!id) return;
       useSelectionStore.getState().selectLayer(id);
     },

--- a/src/stores/project/index.ts
+++ b/src/stores/project/index.ts
@@ -7,6 +7,7 @@ import {
 import { PaperType } from "@/layers/adapters/paper";
 import { HexgridType } from "@/layers/adapters/hexgrid";
 import type { LayerInstance } from "@/layers/types";
+import { nextNumberedName } from "@/stores/project/naming";
 
 export interface Project {
   id: string;
@@ -286,7 +287,14 @@ export const useProjectStore = create<ProjectStoreState>()((set, get) => ({
     const layer: LayerInstance = {
       id: uuid(),
       type: typeId,
-      name: name ?? def.title,
+      name:
+        (name && name.trim()) ||
+        nextNumberedName(
+          def.title,
+          (map.layers ?? [])
+            .filter((l) => l.type === typeId)
+            .map((l) => l.name ?? ""),
+        ),
       visible: true,
       state: def.defaultState,
     };
@@ -319,7 +327,14 @@ export const useProjectStore = create<ProjectStoreState>()((set, get) => ({
     const layer: LayerInstance = {
       id: uuid(),
       type: typeId,
-      name: name ?? def.title,
+      name:
+        (name && name.trim()) ||
+        nextNumberedName(
+          def.title,
+          (map.layers ?? [])
+            .filter((l) => l.type === typeId)
+            .map((l) => l.name ?? ""),
+        ),
       visible: true,
       state: def.defaultState,
     };
@@ -353,7 +368,14 @@ export const useProjectStore = create<ProjectStoreState>()((set, get) => ({
     const layer: LayerInstance = {
       id: uuid(),
       type: typeId,
-      name: name ?? def.title,
+      name:
+        (name && name.trim()) ||
+        nextNumberedName(
+          def.title,
+          (map.layers ?? [])
+            .filter((l) => l.type === typeId)
+            .map((l) => l.name ?? ""),
+        ),
       visible: true,
       state: def.defaultState,
     };

--- a/src/stores/project/naming.ts
+++ b/src/stores/project/naming.ts
@@ -1,0 +1,20 @@
+export function nextNumberedName(
+  baseTitle: string,
+  existingNames: string[],
+): string {
+  const prefix = `${baseTitle} `;
+  let maxN = 0;
+  for (const name of existingNames) {
+    if (!name || !name.startsWith(prefix)) continue;
+    const rest = name.slice(prefix.length);
+    // Accept only pure integer suffixes (ignore "Copy" etc.)
+    if (/^\d{1,}$/.test(rest)) {
+      const n = parseInt(rest, 10);
+      if (Number.isFinite(n) && n > maxN) maxN = n;
+    }
+  }
+  const next = Math.max(1, maxN + 1);
+  // Zero-pad width 2
+  const padded = next.toString().padStart(2, "0");
+  return `${baseTitle} ${padded}`;
+}

--- a/src/test/e2e/layer-naming.spec.ts
+++ b/src/test/e2e/layer-naming.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from "@playwright/test";
+
+async function ensureScenePanelOpen(page: import("@playwright/test").Page) {
+  const panel = page.getByTestId("scene-panel-scroll");
+  if (!(await panel.isVisible())) {
+    await page.getByRole("button", { name: "Toggle Scene Panel" }).click();
+    await expect(panel).toBeVisible();
+  }
+}
+
+test.beforeEach(async ({ context }) => {
+  await context.addInitScript(() => localStorage.clear());
+});
+
+test("Layer numbering and rename in Properties panel", async ({ page }) => {
+  await page.goto("/");
+  await page.getByRole("button", { name: "New Campaign" }).click();
+  await page.getByRole("button", { name: "New Map" }).click();
+  await ensureScenePanelOpen(page);
+
+  // Insert two Hex Noise layers via toolbar
+  const addBtn = page.getByRole("button", { name: "Hex Noise", exact: true });
+  await addBtn.click();
+  await addBtn.click();
+
+  const panel = page.getByTestId("scene-panel-scroll");
+  await expect(panel).toContainText("Hex Noise 01");
+  await expect(panel).toContainText("Hex Noise 02");
+
+  // Select the latest noise layer and rename via Properties
+  await page.getByText("Hex Noise 02", { exact: true }).click();
+  const nameInput = page.getByRole("textbox", { name: "Layer Name" });
+  await expect(nameInput).toBeVisible();
+  await nameInput.fill("Noise Alps");
+  await expect(panel).toContainText("Noise Alps");
+
+  // Duplicate and verify Copy suffix
+  const row = page
+    .getByText("Noise Alps", { exact: true })
+    .locator("..")
+    .locator("..");
+  await row.getByRole("button", { name: "Duplicate Layer" }).click();
+  await expect(panel).toContainText("Noise Alps Copy");
+
+  // Add another Hex Noise; numbering reuses 02 (since numeric 02 was renamed)
+  await addBtn.click();
+  await expect(panel).toContainText("Hex Noise 02");
+});

--- a/src/test/layer-naming-store.test.ts
+++ b/src/test/layer-naming-store.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useProjectStore } from "@/stores/project";
+import { registerLayerType } from "@/layers/registry";
+import { HexNoiseType } from "@/layers/adapters/hex-noise";
+
+describe("Layer naming (store numbering)", () => {
+  beforeEach(() => {
+    // reset store state
+    useProjectStore.setState({ current: null });
+  });
+
+  it("numbers new layers per type with zero padding", () => {
+    registerLayerType(HexNoiseType);
+    const p = useProjectStore.getState().createEmpty({ name: "Test" });
+    useProjectStore.getState().setActive(p);
+    const mapId = useProjectStore.getState().addMap({ name: "M" })!;
+    useProjectStore.getState().selectMap(mapId);
+
+    const id1 = useProjectStore
+      .getState()
+      .insertLayerBeforeTopAnchor("hexnoise");
+    const id2 = useProjectStore
+      .getState()
+      .insertLayerBeforeTopAnchor("hexnoise");
+    expect(id1).toBeTruthy();
+    expect(id2).toBeTruthy();
+
+    const cur = useProjectStore.getState().current!;
+    const map = cur.maps.find((m) => m.id === mapId)!;
+    const n1 = (map.layers ?? []).find((l) => l.id === id1)!.name;
+    const n2 = (map.layers ?? []).find((l) => l.id === id2)!.name;
+    expect(n1).toBe("Hex Noise 01");
+    expect(n2).toBe("Hex Noise 02");
+  });
+
+  it("duplicate keeps Copy suffix and does not renumber others", () => {
+    registerLayerType(HexNoiseType);
+    const p = useProjectStore.getState().createEmpty({ name: "Test" });
+    useProjectStore.getState().setActive(p);
+    const mapId = useProjectStore.getState().addMap({ name: "M" })!;
+    useProjectStore.getState().selectMap(mapId);
+    useProjectStore.getState().insertLayerBeforeTopAnchor("hexnoise")!;
+    const id2 = useProjectStore
+      .getState()
+      .insertLayerBeforeTopAnchor("hexnoise")!; // 02
+    const dupId = useProjectStore.getState().duplicateLayer(id2)!;
+    const cur = useProjectStore.getState().current!;
+    const map = cur.maps.find((m) => m.id === mapId)!;
+    const dupName = (map.layers ?? []).find((l) => l.id === dupId)!.name;
+    expect(dupName).toBe("Hex Noise 02 Copy");
+  });
+
+  it("renaming to a custom name frees the numeric label for reuse", () => {
+    registerLayerType(HexNoiseType);
+    const p = useProjectStore.getState().createEmpty({ name: "Test" });
+    useProjectStore.getState().setActive(p);
+    const mapId = useProjectStore.getState().addMap({ name: "M" })!;
+    useProjectStore.getState().selectMap(mapId);
+    const first = useProjectStore
+      .getState()
+      .insertLayerBeforeTopAnchor("hexnoise")!; // 01
+    useProjectStore.getState().renameLayer(first, "Noise Alps");
+    const id2 = useProjectStore
+      .getState()
+      .insertLayerBeforeTopAnchor("hexnoise")!; // should be 01 again
+    const name2 = useProjectStore
+      .getState()
+      .current!.maps.find((m) => m.id === mapId)!
+      .layers!.find((l) => l.id === id2)!.name;
+    expect(name2).toBe("Hex Noise 01");
+  });
+});


### PR DESCRIPTION
 - Summary: Adds numbered default names for new layers (00-padded, per type/per map), a “Layer Name” field in Properties for inline renaming, and tests. Makes
  Playwright CI-friendly by honoring PORT and CI.
  - Motivation: Clarify layer identity, align rename UX with Campaign/Map, and make E2E assertions stable.
  - Changes:
      - Store: nextNumberedName helper; applied in add/insert paths.
      - UI: Properties panel shows Name for selected layer (uses renameLayer).
      - Plugin: Hex Noise relies on store naming (no hardcoded label).
      - Tests: unit for numbering/duplicate/rename; E2E for numbering + Properties rename.
      - Config: playwright.config.ts reads PORT; CI runs non-interactively.
  - Acceptance
      - Unit/Integration: pnpm test:run → green
      - E2E (CI-style): CI=1 PORT=3210 pnpm test:e2e → green (focused spec also green)
  - Tickets/Docs: T‑017; guidance/feature/layer-naming/*
  - ADRs: Aligns with ADR‑0013 canonical layer order (no changes required).
  - Risk: Low. Purely additive; numbering centralized in store. UI change limited to Properties.
  - Screenshots: N/A (text fields and layer list updates)