### PR TITLE
18 map settings palettes

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,6 +20,30 @@ const eslintConfig = [
       "next-env.d.ts",
     ],
   },
+  {
+    files: ["src/test/**/*.{ts,tsx}", "src/test/**/*.ts"],
+    languageOptions: {
+      globals: {
+        describe: "readonly",
+        it: "readonly",
+        test: "readonly",
+        expect: "readonly",
+        vi: "readonly",
+        beforeEach: "readonly",
+        afterEach: "readonly",
+        beforeAll: "readonly",
+        afterAll: "readonly",
+      },
+    },
+    rules: {
+      "no-console": "off",
+      "react/display-name": "off",
+      "react/jsx-key": "off",
+      "react-hooks/exhaustive-deps": "off",
+      "@next/next/no-img-element": "off",
+      "@typescript-eslint/no-unused-vars": "off",
+    },
+  },
 ];
 
 export default eslintConfig;

--- a/guidance/backlog/status-bar-setting-reactivity.md
+++ b/guidance/backlog/status-bar-setting-reactivity.md
@@ -1,0 +1,39 @@
+---
+title: Status Bar — Setting Indicator Not Reactive
+date: 2025-09-05
+related: T-012 Map Settings / Palettes
+status: Backlog
+---
+
+Context
+
+- The status bar shows the active Setting name based on `AppAPI.palette.settingId()`.
+- After creating a campaign, adding a map, and enabling a map override, the status bar label does not update immediately.
+
+Problem
+
+- No reactive subscription drives re-render when campaign/map `settingId` changes. The status bar reads once per render but does not track palette-setting changes via commands or store updates.
+
+Hypothesis / Root Cause
+
+- `StatusBar` pulls from `useLayoutStore` only; it does not subscribe to project store (where `settingId` lives) nor to a palette-specific store/event. Command handlers mutate project store, but the status bar isn't subscribed.
+
+Proposed Fix (after Campaign/Map → plugins)
+
+- Introduce a lightweight palette state selector hook (e.g., `useActiveSettingId()`), backed by the project store and exposing `map → campaign → default` resolution.
+- Alternatively, emit a palette-changed event from `app.palette.*` commands and subscribe in `StatusBar`.
+
+Acceptance Criteria
+
+- Changing campaign setting updates the status bar within a frame.
+- Enabling/disabling map override updates the status bar accordingly.
+- Switching active map updates the status bar setting label.
+
+Dependencies
+
+- T-012 implemented; Campaign/Map settings available.
+- Optional: palette domain hook or event bus.
+
+Notes
+
+- Parked until Campaign and Map settings UIs are fully pluginized to avoid coupling `StatusBar` to project internals.

--- a/guidance/feature/settings-ux/product_requirements.md
+++ b/guidance/feature/settings-ux/product_requirements.md
@@ -1,0 +1,55 @@
+---
+ticket: T-012
+feature: Map Settings / Palettes
+owner: Georg
+date: 2025-09-05
+level: 2
+---
+
+## Problem & Value
+
+- Unify thematic “settings” (palette + terrain labels/colors) selection to reduce hard‑coded colors and ensure visual consistency across maps.
+- Allow campaign‑level default with per‑map override to balance standardization with creative flexibility (platform optionality).
+- Expose a predictable, read‑only palette surface for plugins and rendering so layers resolve colors/labels from a single source of truth.
+
+## In Scope
+
+- Campaign Settings: choose a `TerrainSetting` from presets; show mood palette preview including `gridLine` and swatches.
+- Map Override: optional toggle to override campaign setting for a specific map; local setting picker when enabled.
+- Map UI Placement: put the override toggle + selector under an "Advanced" group in Map Settings.
+- Inheritance Rules: resolution order `map.settingId → project.settingId → DefaultSetting` (no partial merge).
+- Persistence (IDs only): add `Project.settingId?: string` and `Map.settingId?: string`; runtime derives `MapPalette` via `makePaletteFromSetting()`.
+- Read APIs: confirm/extend `AppAPI.palette.get()`, `terrainFill()`, `gridLine()`, `list()` to reflect the active resolved setting.
+- UX guardrails: keep selection simple; no advanced “unlock” controls in the properties panel yet.
+- Command-Only Mutations: UI changes must invoke commands (no direct store access) to set/clear campaign or map `settingId`.
+- Plugin Migration: migrate the existing plugin to consume `AppAPI.palette` (no hard‑coded colors/labels); verify behavior across multiple presets.
+
+## Out of Scope
+
+- Fine‑grained color editing or custom palette authoring; per‑terrain entry selection by id is deferred.
+- Plugin/app mutation API to change settings (`setSetting(...)`) — follow‑up ticket pending capability design.
+- Migration/healing for existing maps after setting changes (e.g., conflicting layer states); tracked as a separate follow‑up.
+- Property panel “unlockable” capability; not implemented — UI remains basic toggle + picker.
+- Storage/versioning changes beyond adding the two setting IDs (full project format/versioning handled under T‑015).
+
+## Acceptance Criteria
+
+- [ ] Given a campaign with setting X and a new map without override, the map renders using palette derived from X; `AppAPI.palette.get()` returns colors matching X.
+- [ ] Given a campaign with setting X and a map override to Y, that map renders with Y while other maps continue to render with X.
+- [ ] Toggling off a map override reverts that map to the campaign setting on next render without stale colors.
+- [ ] In one campaign with two maps (A,B), with campaign setting X, when A overrides to Y and B has no override, A renders with Y and B renders with X; switching active map does not change either map’s resolved palette.
+- [ ] Campaign Settings UI lists all presets, shows a preview strip (terrain swatches + `gridLine`) and persists `project.settingId`.
+- [ ] Map Settings UI includes an “Override campaign setting for this map” toggle and, when enabled, a local picker that persists `map.settingId`.
+- [ ] All mutations go through commands (e.g., `app.palette.setCampaignSetting`, `app.palette.setMapSetting`, `app.palette.clearMapSetting`); UIs and plugins do not import stores.
+- [ ] `resolvePalette(project, mapId)` returns a palette consistent with the inheritance rules for all combinations (map only, project only, none → default).
+- [ ] No advanced/unlock controls are present in the properties panel; selection flows are limited to setting choose/override only.
+- [ ] The existing plugin reads colors/labels exclusively via `AppAPI.palette` and contains no direct color constants for terrains.
+- [ ] Visual check: with presets A and B selected (e.g., Doom Forge and Space Opera), the plugin’s visuals update to match the active setting without code changes.
+
+## Risks & Assumptions
+
+- Switching settings on an established map may produce visually inconsistent results with existing content; we explicitly defer automated remediation (separate ticket).
+- We assume `DefaultSetting` exists and maps to a valid preset (current default: Doom Forge) for projects/maps with no explicit IDs.
+- Derivation cost is acceptable (O(n) over terrain entries) and can be cached by `settingId` if needed later.
+- Plugins and layers must read colors/labels via `AppAPI.palette`; direct color constants are considered non‑compliant and will be refactored separately.
+- Persistence stores setting IDs only; palette objects remain runtime‑derived to keep a single source of truth.

--- a/guidance/feature/settings-ux/solutions_design.md
+++ b/guidance/feature/settings-ux/solutions_design.md
@@ -1,0 +1,79 @@
+---
+ticket: T-012
+feature: Map Settings / Palettes
+author: Lead Dev
+date: 2025-09-05
+level: 2
+---
+
+## Overview & Assumptions
+
+- Introduce `settingId` at Campaign (`Project`) and Map levels; runtime derives `MapPalette` via existing `makePaletteFromSetting(setting)`.
+- Inheritance: `map.settingId ?? project.settingId ?? DefaultSettingId` with no partial merges.
+- UI surfaces: Campaign Settings gets the primary picker; Map Settings exposes an “Advanced” group with override toggle + local picker.
+- One existing plugin must migrate to `AppAPI.palette` for colors/labels; no hard-coded terrain constants.
+- We keep palette objects ephemeral (runtime only); stores persist IDs to maintain single source of truth.
+
+## Interfaces & Contracts
+
+- Stores (internal)
+  - `Project`: add optional `settingId: string | undefined`.
+  - `Map`: add optional `settingId: string | undefined`.
+  - Selectors (existing): `resolvePalette(project, mapId)` continues to return `MapPalette`; update to respect `settingId` if not already.
+  - Note: stores are accessed only within AppAPI/command handlers; UIs and plugins do not import stores directly.
+
+- App API (`src/appapi/index.ts`)
+  - Read existing: `palette.get()`, `terrainFill(key)`, `gridLine()`, `list(category?)`, `fillById(id)` — ensure they resolve via active `settingId` chain.
+  - Optional helpers: `palette.settingId(): string | null` for UI; defer mutation API.
+
+- Commands (`src/lib/commands.ts`)
+  - Register write commands; handlers perform store mutations:
+    - `app.palette.setCampaignSetting` → payload `{ settingId: string }`.
+    - `app.palette.clearCampaignSetting` → clears `project.settingId`.
+    - `app.palette.setMapSetting` → payload `{ mapId: string, settingId: string }`.
+    - `app.palette.clearMapSetting` → payload `{ mapId: string }`.
+  - UIs invoke via `executeCommand(...)`; success returns updated active `settingId`.
+
+- Palettes Domain
+  - Settings source: `src/palettes/settings.ts` with `getAllSettings()` and lookup by id.
+  - Derivation: `src/palettes/derive.ts` `makePaletteFromSetting(setting)` remains the only construction path for `MapPalette`.
+
+## Data/State Changes
+
+- Schema deltas (in-memory now; persistence handled by T‑015):
+  - `Project`: `{ …, settingId?: string }` default `undefined`.
+  - `Map`: `{ …, settingId?: string }` default `undefined`.
+  - Default resolution uses preset default id (current: `doom-forge`).
+
+## UX Details
+
+- Campaign Settings Panel (treat as first-party plugin)
+  - Control: single-select of presets; preview strip of swatches + `gridLine`.
+  - Action: calls `executeCommand('app.palette.setCampaignSetting',{settingId})`; re-renders maps without overrides.
+
+- Map Settings Panel (Advanced; treat as first-party plugin)
+  - Toggle: “Override campaign setting for this map”.
+  - When enabled: local preset selector; calls `executeCommand('app.palette.setMapSetting',{mapId,settingId})`.
+  - When disabled: calls `executeCommand('app.palette.clearMapSetting',{mapId})`; map resolves to campaign setting.
+
+## Testing Strategy
+
+- Unit
+  - Selector inheritance matrix for `resolvePalette()`.
+  - Derivation invariants: `makePaletteFromSetting()` returns stable colors per setting id.
+  - App API reads reflect resolved setting.
+
+- Integration
+  - Changing campaign setting updates non-overridden maps next render.
+  - Enabling/disabling map override switches palette deterministically.
+
+- E2E
+  - Campaign change flow and Map Advanced override flow across two presets.
+  - Plugin visual probe: swatch expectations vary by active preset.
+
+## Impact/Risks
+
+- Perf: derivation O(n) on change; cache derived palette by `settingId` if change frequency causes churn.
+- DX/UX: placing map override under Advanced reduces accidental divergence.
+- Command Discipline: enforcing command-only mutations keeps plugin/first-party UI decoupled from store internals.
+- ADR links: 0003 map default creation policy, 0007 layer rendering pipeline/masking, 0011 render backend abstraction.

--- a/guidance/feature/settings-ux/tasks.md
+++ b/guidance/feature/settings-ux/tasks.md
@@ -1,0 +1,37 @@
+---
+ticket: T-012
+feature: Map Settings / Palettes
+author: Production Coordinator
+date: 2025-09-05
+level: 2
+---
+
+## Milestones & Gates
+
+- M1: Stores + selectors support `settingId` inheritance (unit tests passing).
+- M2: Campaign Settings UI picker + preview; persists `project.settingId`.
+- M3: Map Settings Advanced override toggle + picker; persists `map.settingId`.
+- M4: Plugin migrated to `AppAPI.palette`; integration test/visual probe passes.
+- Gate: All acceptance criteria satisfied; E2E happy path green on two presets.
+
+## Tasks
+
+- [ ] Add `settingId?: string` to `Project` and `Map` stores; defaults undefined (owner: @dev, est: 0.5d, deps: none)
+- [ ] Update `resolvePalette(project, mapId)` to honor `map.settingId → project.settingId → default` (owner: @dev, est: 0.5d, deps: stores)
+- [ ] Extend `AppAPI.palette.settingId()` helper for UI (read-only) (owner: @dev, est: 0.25d, deps: selectors)
+- [ ] Register commands: `app.palette.setCampaignSetting`, `app.palette.clearCampaignSetting`, `app.palette.setMapSetting`, `app.palette.clearMapSetting` (owner: @dev, est: 0.5d, deps: stores)
+- [ ] Unit tests: selectors inheritance + command handlers (owner: @qa-dev, est: 0.75d, deps: selectors, commands)
+- [ ] Campaign Settings UI: picker + preview; invoke `executeCommand` (no store imports) (owner: @ui-dev, est: 1d, deps: commands)
+- [ ] Map Settings UI (Advanced): override toggle + picker; invoke `executeCommand` (owner: @ui-dev, est: 1d, deps: Campaign UI)
+- [ ] Plugin migration: replace direct colors with `AppAPI.palette` lookups; add minimal integration test (owner: @plugin-dev, est: 0.5d, deps: API stable)
+- [ ] E2E flows: campaign change and map override; probe visuals across two presets (owner: @qa, est: 1d, deps: UIs ready)
+- [ ] Docs: update `guidance/feature/settings-ux/notes.md` cross-links; add usage notes to code where needed (owner: @docs, est: 0.25d, deps: done)
+
+## Validation Hooks
+
+- `pnpm test`: unit/selectors, command handlers, and derivation suite must pass.
+- `pnpm test:e2e`: campaign picker flow and map override flow must pass.
+
+## Rollback / Flag
+
+- Guard with a feature flag `feature.settings.paletteChooser` if needed; fallback to default palette resolution.

--- a/guidance/tickets.md
+++ b/guidance/tickets.md
@@ -42,12 +42,6 @@ T-011 [C] Dual‑Ended Slider for Clamp
 - Links: src/components/properties/\*, hex noise schema
 - Acceptance: Slider adjusts [min,max] with keyboard/mouse; values persist and redraw.
 
-T-012 [C] Map Settings / Palettes
-
-- Goal: Define settings (e.g., high fantasy vs grimdark) that provide terrain categories and colors.
-- Links: store model for map settings, palette provider; noise layer reads palette.
-- Acceptance: Switching setting updates paint mode colors; tests for mapping.
-
 T-013 [C] Performance Pass
 
 - Goal: Profile grid + noise; add caching/batching if beneficial; ensure worker/fallback parity.
@@ -68,9 +62,9 @@ T-015 [M] Save/Load Campaign
 
 Dependencies & Order
 
-- Phase 1: T-004, T-005, T-015
-- Phase 2: T-006, T-007, T-008, T-009b, T-010
-- Phase 3: T-011, T-012, T-013, T-014
+- Phase 1: T-015
+- Phase 2: T-007, T-008, T-009b, T-010
+- Phase 3: T-011, T-013, T-014
 
 ---
 

--- a/src/appapi/index.ts
+++ b/src/appapi/index.ts
@@ -58,21 +58,38 @@ export const AppAPI = {
     },
     // Lists terrain entries from the active setting (MVP: default Doom Forge until settings UI lands)
     list(category?: BaseTerrainType) {
-      const setting = TerrainSettings.DOOM_FORGE; // TODO: wire campaign/map setting selection in T-012
+      const cur = useProjectStore.getState().current;
+      const active = cur?.activeMapId ?? null;
+      const map = cur?.maps.find((m) => m.id === active);
+      const settingId = map?.settingId || cur?.settingId || "doom-forge";
+      const setting =
+        TerrainSettings.getAllSettings().find((s) => s.id === settingId) ??
+        TerrainSettings.DOOM_FORGE;
       return category
         ? setting.terrains.filter((t) => t.baseType === category)
         : setting.terrains.slice();
     },
     // Returns color by terrain entry id from the active setting; falls back to category fill
     fillById(id: string) {
-      const setting = TerrainSettings.DOOM_FORGE;
+      const cur = useProjectStore.getState().current;
+      const active = cur?.activeMapId ?? null;
+      const map = cur?.maps.find((m) => m.id === active);
+      const settingId = map?.settingId || cur?.settingId || "doom-forge";
+      const setting =
+        TerrainSettings.getAllSettings().find((s) => s.id === settingId) ??
+        TerrainSettings.DOOM_FORGE;
       const t = setting.terrains.find((x) => x.id === id);
       if (t) return t.color;
       // Fallback: use category fill via resolved palette
-      const cur = useProjectStore.getState().current;
-      const active = cur?.activeMapId ?? null;
       const palette = resolvePalette(cur, active);
       return resolveTerrainFill(palette, "plains");
+    },
+    // Returns active setting id (map → campaign → default)
+    settingId() {
+      const cur = useProjectStore.getState().current;
+      const active = cur?.activeMapId ?? null;
+      const map = cur?.maps.find((m) => m.id === active);
+      return map?.settingId || cur?.settingId || "doom-forge";
     },
   },
 } as const;

--- a/src/components/layout/app-layout.tsx
+++ b/src/components/layout/app-layout.tsx
@@ -39,6 +39,10 @@ import {
 } from "@/plugin/builtin/new-campaign";
 import { mapCrudManifest, mapCrudModule } from "@/plugin/builtin/map-crud";
 import { hexNoiseManifest, hexNoiseModule } from "@/plugin/builtin/hex-noise";
+import {
+  settingsPaletteManifest,
+  settingsPaletteModule,
+} from "@/plugin/builtin/settings-palette";
 
 import { BaseLayoutProps } from "@/types/layout";
 import { cn } from "@/lib/utils";
@@ -114,6 +118,7 @@ export const AppLayout: React.FC<BaseLayoutProps> = ({
     loadPlugin(newCampaignManifest, newCampaignModule);
     loadPlugin(mapCrudManifest, mapCrudModule);
     loadPlugin(hexNoiseManifest, hexNoiseModule);
+    loadPlugin(settingsPaletteManifest, settingsPaletteModule);
   }, []);
 
   // Sync selection count for status bar

--- a/src/components/layout/status-bar.tsx
+++ b/src/components/layout/status-bar.tsx
@@ -1,21 +1,23 @@
-'use client';
+"use client";
 
 /**
  * StatusBar - Information-rich footer component for the hexmap editor
- * 
- * Displays current active tool, zoom level, mouse coordinates, 
+ *
+ * Displays current active tool, zoom level, mouse coordinates,
  * document save status, and selection information.
- * 
+ *
  * Features:
  * - Fixed height 24px positioned at bottom of layout
  * - Real-time status information display
  * - Integration with layout and tool stores
  */
 
-import React from 'react';
-import { Separator } from '@/components/ui/separator';
+import React from "react";
+import { Separator } from "@/components/ui/separator";
+import { AppAPI } from "@/appapi";
+import { TerrainSettings } from "@/palettes/settings";
 
-import { useLayoutStore } from '@/stores/layout';
+import { useLayoutStore } from "@/stores/layout";
 
 // ============================================================================
 // StatusBar Component
@@ -25,28 +27,30 @@ interface StatusBarProps {
   className?: string;
 }
 
-export const StatusBar: React.FC<StatusBarProps> = ({
-  className = '',
-}) => {
+export const StatusBar: React.FC<StatusBarProps> = ({ className = "" }) => {
   const activeTool = useLayoutStore((state) => state.activeTool);
   const mousePosition = useLayoutStore((state) => state.mousePosition);
   const selectionCount = useLayoutStore((state) => state.selectionCount);
-  
+  const settingId = AppAPI.palette.settingId();
+  const setting = TerrainSettings.getAllSettings().find(
+    (s) => s.id === settingId,
+  );
+
   // Mock zoom level - in real app this would come from a viewport store
   const zoomLevel = 100;
-  
+
   /**
    * Format tool name for display
    */
   const formatToolName = (tool: string): string => {
     const toolNames: Record<string, string> = {
-      select: 'Select',
-      paint: 'Hex Paint',
-      draw: 'Draw',
-      erase: 'Erase',
-      text: 'Text',
-      zoom: 'Zoom',
-      grid: 'Grid',
+      select: "Select",
+      paint: "Hex Paint",
+      draw: "Draw",
+      erase: "Erase",
+      text: "Text",
+      zoom: "Zoom",
+      grid: "Grid",
     };
     return toolNames[tool] || tool.charAt(0).toUpperCase() + tool.slice(1);
   };
@@ -56,56 +60,73 @@ export const StatusBar: React.FC<StatusBarProps> = ({
    */
   const formatSelectionInfo = (): string => {
     if (selectionCount === 0) {
-      return 'No selection';
+      return "No selection";
     }
     if (selectionCount === 1) {
-      return '1 selected';
+      return "1 selected";
     }
     return `${selectionCount} selected`;
   };
 
   return (
-    <div data-testid="status-bar" className={`h-6 border-t bg-muted/30 text-xs flex items-center px-3 gap-4 ${className}`}>
+    <div
+      data-testid="status-bar"
+      className={`h-6 border-t bg-muted/30 text-xs flex items-center px-3 gap-4 ${className}`}
+    >
       {/* Active Tool */}
       <div className="flex items-center gap-1">
         <span className="font-medium">Tool:</span>
         <span>{formatToolName(activeTool)}</span>
       </div>
-      
+
       <Separator orientation="vertical" className="h-4" />
-      
+
       {/* Zoom Level */}
       <div className="flex items-center gap-1">
         <span className="font-medium">Zoom:</span>
         <span>{zoomLevel}%</span>
       </div>
-      
+
       <Separator orientation="vertical" className="h-4" />
-      
+
       {/* Mouse Coordinates */}
       <div className="flex items-center gap-1">
         <span className="font-medium">Position:</span>
-        <span>X: {mousePosition.x}, Y: {mousePosition.y}</span>
+        <span>
+          X: {mousePosition.x}, Y: {mousePosition.y}
+        </span>
       </div>
-      
+
       <Separator orientation="vertical" className="h-4" />
-      
+
+      {/* Active Setting */}
+      <div className="flex items-center gap-1">
+        <span className="font-medium">Setting:</span>
+        <span>{setting?.name ?? settingId}</span>
+      </div>
+
+      <Separator orientation="vertical" className="h-4" />
+
       {/* Hex Coordinates */}
       <div className="flex items-center gap-1">
         <span className="font-medium">Hex:</span>
-        <span>{mousePosition.hex ? `${mousePosition.hex.q}, ${mousePosition.hex.r}` : '—'}</span>
+        <span>
+          {mousePosition.hex
+            ? `${mousePosition.hex.q}, ${mousePosition.hex.r}`
+            : "—"}
+        </span>
       </div>
-      
+
       {/* Spacer */}
       <div className="flex-1" />
-      
+
       {/* Selection Info */}
       <div className="flex items-center gap-1">
         <span>{formatSelectionInfo()}</span>
       </div>
-      
+
       <Separator orientation="vertical" className="h-4" />
-      
+
       {/* Document Status */}
       <div className="flex items-center gap-1">
         <span className="text-muted-foreground">●</span>

--- a/src/components/map/canvas-viewport.tsx
+++ b/src/components/map/canvas-viewport.tsx
@@ -275,8 +275,12 @@ export const CanvasViewport: React.FC = () => {
             ctx.fill();
             return;
           }
-          const terrain = (st.terrain as string | undefined) ?? "plains";
-          const fill = resolveTerrainFill(palette, terrain);
+          const fill =
+            (st.paintColor as string | undefined) ??
+            resolveTerrainFill(
+              palette,
+              (st.terrain as string | undefined) ?? "plains",
+            );
           ctx.beginPath();
           for (let i = 0; i < 6; i++) {
             const ang = startAngle + i * (Math.PI / 3);

--- a/src/plugin/builtin/hex-noise.ts
+++ b/src/plugin/builtin/hex-noise.ts
@@ -3,6 +3,7 @@ import { registerLayerType } from "@/layers/registry";
 import { HexNoiseType } from "@/layers/adapters/hex-noise";
 import { useProjectStore } from "@/stores/project";
 import { useSelectionStore } from "@/stores/selection";
+import { AppAPI } from "@/appapi";
 
 export const hexNoiseManifest: PluginManifest = {
   id: "app.plugins.hex-noise",
@@ -54,6 +55,20 @@ export const hexNoiseModule: PluginModule = {
             .insertLayerBeforeTopAnchor("hexnoise");
         }
         if (!id) return;
+        // Initialize defaults: paint mode and first terrain entry color
+        try {
+          const entries = AppAPI.palette.list();
+          const first = entries[0];
+          if (first) {
+            useProjectStore.getState().updateLayerState(id, {
+              mode: "paint",
+              terrainId: first.id,
+              paintColor: first.color,
+            });
+          } else {
+            useProjectStore.getState().updateLayerState(id, { mode: "paint" });
+          }
+        } catch {}
         useSelectionStore.getState().selectLayer(id);
         return;
       } else if (sel.kind === "map") {
@@ -61,6 +76,19 @@ export const hexNoiseModule: PluginModule = {
           .getState()
           .insertLayerBeforeTopAnchor("hexnoise");
         if (!id) return;
+        try {
+          const entries = AppAPI.palette.list();
+          const first = entries[0];
+          if (first) {
+            useProjectStore.getState().updateLayerState(id, {
+              mode: "paint",
+              terrainId: first.id,
+              paintColor: first.color,
+            });
+          } else {
+            useProjectStore.getState().updateLayerState(id, { mode: "paint" });
+          }
+        } catch {}
         useSelectionStore.getState().selectLayer(id);
         return;
       }
@@ -69,6 +97,19 @@ export const hexNoiseModule: PluginModule = {
         .getState()
         .insertLayerBeforeTopAnchor("hexnoise");
       if (!id) return;
+      try {
+        const entries = AppAPI.palette.list();
+        const first = entries[0];
+        if (first) {
+          useProjectStore.getState().updateLayerState(id, {
+            mode: "paint",
+            terrainId: first.id,
+            paintColor: first.color,
+          });
+        } else {
+          useProjectStore.getState().updateLayerState(id, { mode: "paint" });
+        }
+      } catch {}
       useSelectionStore.getState().selectLayer(id);
     },
   },

--- a/src/plugin/builtin/settings-palette.ts
+++ b/src/plugin/builtin/settings-palette.ts
@@ -1,0 +1,47 @@
+import type { PluginManifest, PluginModule } from "@/plugin/types";
+import { useProjectStore } from "@/stores/project";
+
+export const settingsPaletteManifest: PluginManifest = {
+  id: "app.plugins.settings.palette",
+  name: "Settings: Palette Commands",
+  version: "0.1.0",
+  apiVersion: "1.0",
+  contributes: {
+    commands: [
+      { id: "app.palette.setCampaignSetting", title: "Set Campaign Setting" },
+      {
+        id: "app.palette.clearCampaignSetting",
+        title: "Clear Campaign Setting",
+      },
+      { id: "app.palette.setMapSetting", title: "Set Map Setting" },
+      { id: "app.palette.clearMapSetting", title: "Clear Map Setting" },
+    ],
+  },
+};
+
+export const settingsPaletteModule: PluginModule = {
+  commands: {
+    "app.palette.setCampaignSetting": async (payload?: unknown) => {
+      const id = (payload as { settingId?: string } | undefined)?.settingId;
+      useProjectStore.getState().setCampaignSetting(id);
+      return { settingId: id ?? null };
+    },
+    "app.palette.clearCampaignSetting": async () => {
+      useProjectStore.getState().setCampaignSetting(undefined);
+      return { settingId: null };
+    },
+    "app.palette.setMapSetting": async (payload?: unknown) => {
+      const { mapId, settingId } =
+        (payload as { mapId?: string; settingId?: string }) ?? {};
+      if (!mapId) return { error: "mapId required" };
+      useProjectStore.getState().setMapSetting(mapId, settingId);
+      return { mapId, settingId: settingId ?? null };
+    },
+    "app.palette.clearMapSetting": async (payload?: unknown) => {
+      const { mapId } = (payload as { mapId?: string }) ?? {};
+      if (!mapId) return { error: "mapId required" };
+      useProjectStore.getState().setMapSetting(mapId, undefined);
+      return { mapId, settingId: null };
+    },
+  },
+};

--- a/src/test/palette-settings.test.ts
+++ b/src/test/palette-settings.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useProjectStore } from "@/stores/project";
+import { resolvePalette } from "@/stores/selectors/palette";
+import {
+  executeCommand,
+  registerCommand,
+  unregisterCommand,
+} from "@/lib/commands";
+import {
+  settingsPaletteManifest,
+  settingsPaletteModule,
+} from "@/plugin/builtin/settings-palette";
+import { loadPlugin } from "@/plugin/loader";
+
+describe("T-012 Settings / Palettes", () => {
+  beforeEach(() => {
+    useProjectStore.setState({ current: null });
+    // Register commands (idempotent via loader)
+    loadPlugin(settingsPaletteManifest, settingsPaletteModule);
+  });
+
+  it("resolves palette by project settingId when no map override", () => {
+    const p = useProjectStore.getState().createEmpty({ name: "Test" });
+    const mapId = useProjectStore.getState().addMap({ name: "A" });
+    useProjectStore.getState().selectMap(mapId);
+    // set campaign setting to space-opera
+    useProjectStore.getState().setCampaignSetting("space-opera");
+    const pal = resolvePalette(useProjectStore.getState().current, mapId);
+    expect(pal.grid.line).toBeDefined();
+  });
+
+  it("supports two maps with different effective settings", async () => {
+    const p = useProjectStore.getState().createEmpty({ name: "Test" });
+    const a = useProjectStore.getState().addMap({ name: "A" });
+    const b = useProjectStore.getState().addMap({ name: "B" });
+    // campaign setting X
+    await executeCommand("app.palette.setCampaignSetting", {
+      settingId: "doom-forge",
+    });
+    // map A override to Y
+    await executeCommand("app.palette.setMapSetting", {
+      mapId: a,
+      settingId: "space-opera",
+    });
+
+    const palA = resolvePalette(useProjectStore.getState().current, a);
+    const palB = resolvePalette(useProjectStore.getState().current, b);
+    expect(palA.grid.line).not.toEqual(palB.grid.line);
+  });
+
+  it("clearing map override reverts to campaign setting", async () => {
+    const p = useProjectStore.getState().createEmpty({ name: "Test" });
+    const a = useProjectStore.getState().addMap({ name: "A" });
+    await executeCommand("app.palette.setCampaignSetting", {
+      settingId: "doom-forge",
+    });
+    await executeCommand("app.palette.setMapSetting", {
+      mapId: a,
+      settingId: "space-opera",
+    });
+    const before = resolvePalette(useProjectStore.getState().current, a);
+    await executeCommand("app.palette.clearMapSetting", { mapId: a });
+    const after = resolvePalette(useProjectStore.getState().current, a);
+    expect(after.grid.line).not.toEqual(before.grid.line);
+  });
+});


### PR DESCRIPTION
- **docs(todos): add layer renaming requirement**
- **docs(process): add role processes and templates; QA as correlation role**
- **feat(store): t-017 layer naming defaults + properties rename + e2e config**
- **docs(backlog): prune delivered tickets and move todos into backlog file**
- **feat(plugin): plugin-toolbar-contract with capability registry and toolbar gating**
- **docs(process): introduce Platform-First MVP policy and checklist; link from guides**
- **feat(invalidation): require getInvalidationKey for visual layers**
- **feat(render,docs,test)!: require adapter invalidation keys; enforce in host; add pipeline/E2E probe**
- **docs(implementation): update Forward-Ever phase policy and clarify migration rules**
- **docs(feature): introduce unified hex geometry and pointer routing API**
- **chore(deps): update vitest coverage configuration and add coverage-v8 dependency**
- **feat(viewport): integrate AppAPI for hex coordinate conversion and enhance mouse position tracking**
- **test: add Playwright E2E job and run in CI (T-005)**
- **feat(palette): inject terrain palettes from settings (T-006)**
- **feat(settings-ux): map settings + hex-noise (t-012)**
